### PR TITLE
Add venue to ASK_CANCELLED and BID_CANCELLED

### DIFF
--- a/src/db/channels.js
+++ b/src/db/channels.js
@@ -57,6 +57,7 @@ const deferrals = events.channel("erc721_transfers_deferred");
 //        projectId: string,
 //        slug: string,
 //        tokenIndex: number,
+//        venue: "ARCHIPELAGO" | "OPENSEA",
 //      }
 //
 //  - For `type: "BID_PLACED"`, `data` looks like:
@@ -70,7 +71,7 @@ const deferrals = events.channel("erc721_transfers_deferred");
 //        bidId: string,
 //        projectId: string,
 //        slug: string,
-//        venue: "ARCHIPELAGO" | "OPENSEA",
+//        venue: "ARCHIPELAGO",
 //        bidder: address (0xstring),
 //        currency: "ETH",
 //        price: string(wei),
@@ -84,6 +85,7 @@ const deferrals = events.channel("erc721_transfers_deferred");
 //        bidId: string,
 //        projectId: string,
 //        slug: string,
+//        venue: "ARCHIPELAGO",
 //      }
 //
 //  - For `type: "TOKEN_MINTED"`, `data` looks like:

--- a/src/db/orderbook.js
+++ b/src/db/orderbook.js
@@ -268,6 +268,7 @@ async function sendBidActivityMessages({ client, bidIds }) {
           bidId: row.bidId,
           projectId: row.projectId,
           slug: row.slug,
+          venue: "ARCHIPELAGO",
         },
       });
     }
@@ -309,6 +310,7 @@ async function sendAskActivityMessages({ client, askIds }) {
           projectId: row.projectId,
           slug: row.slug,
           tokenIndex: row.tokenIndex,
+          venue: "ARCHIPELAGO",
         },
       });
     }


### PR DESCRIPTION
This cleans up an inconsistency in a couple of the WebSocket messages. `venue` will now be present in the `ASK_CANCELLED` and `BID_CANCELLED` events in all cases.